### PR TITLE
feat: add watch progress resume experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { ContentSearch } from '@/components/content-search'
 import { AllContentBrowser } from '@/components/all-content-browser'
 import { UltraSearch } from '@/components/ultra-search'
 import { WatchlistView } from '@/components/watchlist-view'
-import { NetflixScrollToTop } from '@/components/netflix-enhancement'
+import { NetflixScrollToTop, NetflixToast } from '@/components/netflix-enhancement'
 import { WelcomeModal } from '@/components/welcome-modal'
 import { SettingsPage } from '@/components/settings-page'
 import { AuthPage } from '@/pages/auth-page'
@@ -17,6 +17,7 @@ import { ProfilePage } from '@/pages/profile-page'
 import { tmdbService, type ContentItem, type EpisodeDetails } from '@/services/tmdb-service'
 import { authService } from '@/services/auth-service'
 import { watchlistService } from '@/services/watchlist-service'
+import { watchProgressService } from '@/services/watch-progress-service'
 import { settingsService } from '@/services/settings-service'
 import { Button } from '@/components/ui/button'
 import { ArrowLeft, Settings, ChevronDown, PlayCircle } from 'lucide-react'
@@ -28,6 +29,7 @@ import { ChangelogPage } from '@/components/changelog-page'
 import { AnimePage } from '@/components/anime-page'
 import { AnimeSection } from '@/components/anime-section'
 import { MovieSuggestions } from '@/components/movie-suggestions'
+import type { PlaybackOptions } from '@/types/playback'
 
 type ExtendedContentItem = ContentItem & {
   similar?: ContentItem[];
@@ -43,6 +45,7 @@ function RequireAuth({ children }: { children: ReactNode }) {
     const unsubscribe = authService.addListener((state) => {
       setAuthState(state);
       watchlistService.setUserContext(state.user?.id ?? null);
+      watchProgressService.setUserContext(state.user?.id ?? null);
       setInitialising(false);
     });
 
@@ -203,7 +206,7 @@ function PlayerPage() {
   const [subtitleTimerRunning, setSubtitleTimerRunning] = useState(false);
   const [showSettingsDropdown, setShowSettingsDropdown] = useState(false);
   const [uploadedSubtitle, setUploadedSubtitle] = useState<{ url: string; label: string } | null>(null);
-  const [streamContext, setStreamContext] = useState<{ id: number | string; type: 'movie' | 'tv'; season?: number; episode?: number } | null>(null);
+  const [streamContext, setStreamContext] = useState<{ id: number | string; type: 'movie' | 'tv'; season?: number; episode?: number; resumeAt?: number | null } | null>(null);
   const [useVipStream, setUseVipStream] = useState(false);
   const [autoplayEnabled, setAutoplayEnabled] = useState(
     () => authService.getCurrentUser()?.preferences.autoplay ?? true
@@ -212,6 +215,9 @@ function PlayerPage() {
   const [seasonEpisodesVersion, setSeasonEpisodesVersion] = useState(0);
   const autoplayTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const autoplayTriggerRef = useRef<{ key: string; triggered: boolean }>({ key: '', triggered: false });
+  const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastKnownPositionRef = useRef(0);
+  const lastKnownDurationRef = useRef<number | null>(null);
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -312,16 +318,37 @@ function PlayerPage() {
             const urlParams = new URLSearchParams(window.location.search);
             const seasonParam = urlParams.get('s') ?? urlParams.get('season');
             const episodeParam = urlParams.get('e') ?? urlParams.get('episode');
+            const timeParam = urlParams.get('t') ?? urlParams.get('start') ?? urlParams.get('time');
             const seasonNumber = seasonParam ? Number(seasonParam) : undefined;
             const episodeNumber = episodeParam ? Number(episodeParam) : undefined;
             const resolvedSeason = seasonNumber ?? (data.type === 'tv' ? 1 : undefined);
             const resolvedEpisode = episodeNumber ?? (data.type === 'tv' ? 1 : undefined);
+            const savedProgress = data.tmdb_id ? watchProgressService.getLatestProgress(data.tmdb_id, data.type) : null;
+            let nextSeason = resolvedSeason;
+            let nextEpisode = resolvedEpisode;
+
+            if (savedProgress && data.type === 'tv' && !seasonNumber && !episodeNumber) {
+              nextSeason = savedProgress.season ?? resolvedSeason;
+              nextEpisode = savedProgress.episode ?? resolvedEpisode;
+            }
+
+            const parsedResume = timeParam ? Number(timeParam) : null;
+            const resumeFromQuery = parsedResume !== null && !Number.isNaN(parsedResume) ? Math.max(0, parsedResume) : null;
+            const resumeAt = resumeFromQuery ?? (savedProgress ? savedProgress.positionSeconds : null);
+
+            if (resumeAt && resumeAt > 0) {
+              lastKnownPositionRef.current = resumeAt;
+            } else {
+              lastKnownPositionRef.current = 0;
+            }
+            lastKnownDurationRef.current = savedProgress?.durationSeconds ?? null;
 
             setStreamContext({
               id: data.imdb_id ?? data.id,
               type: mediaType as 'movie' | 'tv',
-              season: resolvedSeason,
-              episode: resolvedEpisode
+              season: nextSeason,
+              episode: nextEpisode,
+              resumeAt,
             });
           }
         }
@@ -340,8 +367,8 @@ function PlayerPage() {
       return;
     }
 
-    const { id, type, season, episode } = streamContext;
-    const extras: { useVip?: true; subtitle?: { url: string; label: string } } = {};
+    const { id, type, season, episode, resumeAt } = streamContext;
+    const extras: { useVip?: true; subtitle?: { url: string; label: string }; startTimeSeconds?: number; autoplay?: boolean } = {};
 
     if (uploadedSubtitle) {
       extras.subtitle = uploadedSubtitle;
@@ -351,10 +378,175 @@ function PlayerPage() {
       extras.useVip = true;
     }
 
-    const extrasArg = extras.subtitle || extras.useVip ? extras : undefined;
+    if (resumeAt && resumeAt > 0) {
+      extras.startTimeSeconds = resumeAt;
+      extras.autoplay = true;
+    }
+
+    const extrasArg = extras.subtitle || extras.useVip || extras.startTimeSeconds || extras.autoplay ? extras : undefined;
     const updatedUrl = tmdbService.getStreamingUrl(id, type, season, episode, extrasArg);
     setEmbedUrl(updatedUrl);
   }, [streamContext, uploadedSubtitle, useVipStream]);
+
+  useEffect(() => {
+    if (!content) {
+      return;
+    }
+
+    const parsePayload = (payload: unknown): { currentTime: number | null; duration: number | null } | null => {
+      const parseNumber = (value: unknown): number | null => {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const parsed = Number(value);
+          if (!Number.isNaN(parsed)) {
+            return parsed;
+          }
+        }
+        return null;
+      };
+
+      let data = payload;
+
+      if (typeof data === 'string') {
+        try {
+          data = JSON.parse(data);
+        } catch {
+          const numericMatch = (data as string).match(/\d+(?:\.\d+)?/g);
+          if (numericMatch && numericMatch.length > 0) {
+            const current = Number(numericMatch[0]);
+            const duration = numericMatch.length > 1 ? Number(numericMatch[1]) : null;
+            return {
+              currentTime: Number.isNaN(current) ? null : current,
+              duration: duration !== null && !Number.isNaN(duration) ? duration : null,
+            };
+          }
+        }
+      }
+
+      if (typeof data === 'object' && data !== null) {
+        const currentTime = parseNumber((data as Record<string, unknown>).currentTime
+          ?? (data as Record<string, unknown>).time
+          ?? (data as Record<string, unknown>).position
+          ?? (data as Record<string, unknown>).current_seconds
+          ?? (data as Record<string, unknown>).seconds);
+
+        const duration = parseNumber((data as Record<string, unknown>).duration
+          ?? (data as Record<string, unknown>).length
+          ?? (data as Record<string, unknown>).total);
+
+        if (currentTime !== null || duration !== null) {
+          return { currentTime, duration };
+        }
+      }
+
+      return null;
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      const extracted = parsePayload(event.data);
+      if (!extracted) {
+        return;
+      }
+
+      const { currentTime, duration } = extracted;
+
+      if (currentTime !== null) {
+        lastKnownPositionRef.current = currentTime;
+        setStreamContext((prev) => {
+          if (!prev) {
+            return prev;
+          }
+          if (!prev.resumeAt || Math.abs(prev.resumeAt - currentTime) >= 5) {
+            return { ...prev, resumeAt: currentTime };
+          }
+          return prev;
+        });
+      }
+
+      if (duration !== null) {
+        lastKnownDurationRef.current = duration;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, [content, streamContext?.season, streamContext?.episode]);
+
+  useEffect(() => {
+    if (!content) {
+      return;
+    }
+
+    const isTv = content.type === 'tv';
+
+    const persistProgress = (force = false) => {
+      if (!content.tmdb_id) {
+        return;
+      }
+
+      if (isTv && (!streamContext?.season || !streamContext?.episode)) {
+        return;
+      }
+
+      const metadata = {
+        tmdbId: content.tmdb_id,
+        imdbId: content.imdb_id ?? undefined,
+        mediaType: content.type,
+        season: isTv ? streamContext?.season : undefined,
+        episode: isTv ? streamContext?.episode : undefined,
+        title: content.title,
+        poster: content.poster ?? null,
+        backdropPath: content.backdropPath ?? null,
+        episodeTitle: null as string | null,
+      };
+
+      if (isTv && streamContext?.season && streamContext?.episode) {
+        const episodes = seasonEpisodesRef.current[streamContext.season];
+        const match = episodes?.find((ep) => ep.episodeNumber === streamContext.episode);
+        metadata.episodeTitle = match?.name ?? null;
+      }
+
+      watchProgressService.updateProgress(metadata, {
+        positionSeconds: lastKnownPositionRef.current,
+        durationSeconds: lastKnownDurationRef.current ?? undefined,
+        force,
+      });
+    };
+
+    if (progressIntervalRef.current) {
+      clearInterval(progressIntervalRef.current);
+      progressIntervalRef.current = null;
+    }
+
+    progressIntervalRef.current = setInterval(() => persistProgress(false), 15000);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        persistProgress(true);
+      }
+    };
+
+    const handleBeforeUnload = () => {
+      persistProgress(true);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      if (progressIntervalRef.current) {
+        clearInterval(progressIntervalRef.current);
+        progressIntervalRef.current = null;
+      }
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      persistProgress(true);
+    };
+  }, [content, streamContext]);
 
   const handleBack = () => {
     navigate(-1);
@@ -511,16 +703,29 @@ function PlayerPage() {
     }
 
     const streamId = streamContext?.id ?? content.imdb_id ?? content.id;
+    const savedProgress = content.tmdb_id
+      ? watchProgressService.getProgress({ tmdbId: content.tmdb_id, mediaType: 'tv', season: seasonNumber, episode: episodeNumber })
+      : null;
+
+    lastKnownPositionRef.current = savedProgress?.positionSeconds ?? 0;
+    lastKnownDurationRef.current = savedProgress?.durationSeconds ?? null;
+
     setStreamContext({
       id: streamId,
       type: 'tv',
       season: seasonNumber,
       episode: episodeNumber,
+      resumeAt: savedProgress?.positionSeconds ?? null,
     });
 
     const searchParams = new URLSearchParams(window.location.search);
     searchParams.set('s', String(seasonNumber));
     searchParams.set('e', String(episodeNumber));
+    if (savedProgress?.positionSeconds) {
+      searchParams.set('t', Math.floor(savedProgress.positionSeconds).toString());
+    } else {
+      searchParams.delete('t');
+    }
     navigate(`/watch/${content.type}/${content.tmdb_id}?${searchParams.toString()}`, { replace: true });
   }, [content, navigate, streamContext]);
 
@@ -548,8 +753,10 @@ function PlayerPage() {
       const currentIndex = sortedEpisodes.findIndex((episode) => episode.episodeNumber === currentEpisode);
       if (currentIndex > -1 && currentIndex < sortedEpisodes.length - 1) {
         const nextEpisode = sortedEpisodes[currentIndex + 1];
-        updateEpisodeContext(nextEpisode.seasonNumber ?? currentSeason, nextEpisode.episodeNumber);
-        return;
+        if (nextEpisode) {
+          updateEpisodeContext(nextEpisode.seasonNumber ?? currentSeason, nextEpisode.episodeNumber);
+          return;
+        }
       }
     }
 
@@ -878,6 +1085,7 @@ function PlayerPage() {
 // Main App Component
 function MainApp() {
   const [showWelcome, setShowWelcome] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     // Check if setup is needed
@@ -891,9 +1099,24 @@ function MainApp() {
     checkSetup();
   }, []);
 
-  const handlePlayContent = (content: ContentItem) => {
-    // Navigate to player with the content
-    window.location.href = `/watch/${content.type}/${content.tmdb_id}`;
+  const handlePlayContent = (content: ContentItem, options?: PlaybackOptions) => {
+    const params = new URLSearchParams();
+
+    if (options?.season) {
+      params.set('s', options.season.toString());
+    }
+
+    if (options?.episode) {
+      params.set('e', options.episode.toString());
+    }
+
+    if (options?.resumeAt) {
+      params.set('t', Math.floor(options.resumeAt).toString());
+    }
+
+    const query = params.toString();
+    const path = `/watch/${content.type}/${content.tmdb_id}`;
+    navigate(query ? `${path}?${query}` : path);
   };
 
   const handleCloseWelcome = () => {
@@ -1056,6 +1279,7 @@ function MainApp() {
         onClose={handleCloseWelcome}
         onOpenSettings={handleOpenSettings}
       />
+      <NetflixToast />
     </div>
   );
 }

--- a/src/components/all-content-browser.tsx
+++ b/src/components/all-content-browser.tsx
@@ -701,8 +701,25 @@ export function AllContentBrowser({
                         seasons: item.seasons || undefined,
                         episodes: item.episodes || undefined
                       }}
-                      onPlay={() => {
+                      onPlay={(_contentId, options) => {
                         const contentId = item.tmdb_id || item.id;
+                        const params = new URLSearchParams();
+                        if (options?.season) {
+                          params.set('s', options.season.toString());
+                        }
+                        if (options?.episode) {
+                          params.set('e', options.episode.toString());
+                        }
+                        if (options?.resumeAt) {
+                          params.set('t', Math.floor(options.resumeAt).toString());
+                        }
+
+                        if (params.size > 0) {
+                          const query = params.toString();
+                          navigate(`/watch/${item.type}/${contentId}?${query}`);
+                          return;
+                        }
+
                         navigate(`/details/${item.type}/${contentId}`);
                       }}
                       compact={viewMode === 'list'}
@@ -783,8 +800,25 @@ export function AllContentBrowser({
                           seasons: item.seasons || undefined,
                           episodes: item.episodes || undefined
                         }}
-                        onPlay={() => {
+                        onPlay={(_contentId, options) => {
                           const contentId = item.tmdb_id || item.id;
+                          const params = new URLSearchParams();
+                          if (options?.season) {
+                            params.set('s', options.season.toString());
+                          }
+                          if (options?.episode) {
+                            params.set('e', options.episode.toString());
+                          }
+                          if (options?.resumeAt) {
+                            params.set('t', Math.floor(options.resumeAt).toString());
+                          }
+
+                          if (params.size > 0) {
+                            const query = params.toString();
+                            navigate(`/watch/${item.type}/${contentId}?${query}`);
+                            return;
+                          }
+
                           navigate(`/details/${item.type}/${contentId}`);
                         }}
                         compact={viewMode === 'list'}

--- a/src/components/batch-content-loader.tsx
+++ b/src/components/batch-content-loader.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { performanceOptimizationService } from '@/services/performance-optimization-service';
 import LazyNetflixCard from './lazy-netflix-card';
+import type { PlaybackOptions } from '@/types/playback';
 
 interface BatchContentLoaderProps {
   content: Array<{
@@ -20,7 +21,7 @@ interface BatchContentLoaderProps {
     episodes?: number;
     tmdb_id?: number;
   }>;
-  onPlay: (contentId: string) => void;
+  onPlay: (contentId: string, options?: PlaybackOptions) => void;
   onAddToList?: (contentId: string) => void;
   size?: 'small' | 'medium' | 'large';
   compact?: boolean;

--- a/src/components/content-details.tsx
+++ b/src/components/content-details.tsx
@@ -1,11 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Play, Plus, ArrowLeft, Star, Calendar, Clock, Tv, Heart } from 'lucide-react';
+import { Play, Plus, ArrowLeft, Star, Calendar, Clock, Tv, Heart, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Card, CardContent } from '@/components/ui/card';
 import { tmdbService, type ContentItem } from '@/services/tmdb-service';
+import { useWatchProgress } from '@/hooks/use-watch-progress';
+import type { PlaybackOptions } from '@/types/playback';
 import { watchlistService } from '@/services/watchlist-service';
 
 export function ContentDetails() {
@@ -17,6 +19,47 @@ export function ContentDetails() {
   const [selectedEpisode, setSelectedEpisode] = useState('1');
   const [isInWatchlist, setIsInWatchlist] = useState(false);
   const [similarContent, setSimilarContent] = useState<ContentItem[]>([]);
+  const resumeProgress = useWatchProgress(content?.tmdb_id, content?.type);
+  const resumeAvailable = !!(resumeProgress && resumeProgress.positionSeconds > 5);
+
+  const resumeDetails = useMemo(() => {
+    if (!resumeAvailable || !resumeProgress) {
+      return null as null | {
+        timeLabel: string;
+        episodeLabel: string | null;
+      };
+    }
+
+    const totalSeconds = Math.floor(resumeProgress.positionSeconds);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const parts: string[] = [];
+    if (hours > 0) {
+      parts.push(`${hours}h`);
+    }
+    if (minutes > 0 || hours === 0) {
+      parts.push(`${minutes}m`);
+    }
+    if (hours === 0 && minutes === 0) {
+      parts.push(`${seconds}s`);
+    }
+
+    const episodeLabel = content?.type === 'tv'
+      ? [
+          resumeProgress.season ? `S${resumeProgress.season}` : null,
+          resumeProgress.episode ? `E${resumeProgress.episode}` : null,
+        ]
+          .filter(Boolean)
+          .join('') || 'Episode'
+      : null;
+
+    return {
+      timeLabel: parts.join(' '),
+      episodeLabel,
+    };
+  }, [content?.type, resumeAvailable, resumeProgress]);
 
   useEffect(() => {
     const loadContent = async () => {
@@ -82,24 +125,35 @@ export function ContentDetails() {
     loadContent();
   }, [contentId, mediaType]);
 
-  const handlePlay = () => {
+  const handlePlay = (options?: PlaybackOptions) => {
     if (!content) return;
-    
+
     // Use TMDB ID consistently with media type
     const id = content.tmdb_id;
-    
+
     if (content.type === 'tv') {
-      // For TV shows, include season and episode in the URL
-      navigate(`/watch/${content.type}/${id}?s=${selectedSeason}&e=${selectedEpisode}`);
+      const seasonValue = options?.season ?? Number(selectedSeason);
+      const episodeValue = options?.episode ?? Number(selectedEpisode);
+      const params = new URLSearchParams();
+      params.set('s', String(seasonValue));
+      params.set('e', String(episodeValue));
+      if (options?.resumeAt) {
+        params.set('t', Math.floor(options.resumeAt).toString());
+      }
+      navigate(`/watch/${content.type}/${id}?${params.toString()}`);
     } else {
-      // For movies, also include media type
-      navigate(`/watch/${content.type}/${id}`);
+      const params = new URLSearchParams();
+      if (options?.resumeAt) {
+        params.set('t', Math.floor(options.resumeAt).toString());
+      }
+      const query = params.toString();
+      navigate(query ? `/watch/${content.type}/${id}?${query}` : `/watch/${content.type}/${id}`);
     }
   };
 
   const handleAddToWatchlist = () => {
     if (!content) return;
-    
+
     if (isInWatchlist) {
       const removed = watchlistService.removeFromWatchlist(content.tmdb_id.toString());
       if (removed) setIsInWatchlist(false);
@@ -118,6 +172,25 @@ export function ContentDetails() {
       const added = watchlistService.addToWatchlist(watchlistItem);
       if (added) setIsInWatchlist(true);
     }
+  };
+
+  const handleResume = () => {
+    if (!resumeProgress || !content) {
+      return;
+    }
+
+    if (resumeProgress.season) {
+      setSelectedSeason(String(resumeProgress.season));
+    }
+    if (resumeProgress.episode) {
+      setSelectedEpisode(String(resumeProgress.episode));
+    }
+
+    handlePlay({
+      resumeAt: resumeProgress.positionSeconds,
+      season: resumeProgress.season,
+      episode: resumeProgress.episode,
+    });
   };
 
   const handleBack = () => {
@@ -284,14 +357,28 @@ export function ContentDetails() {
               {/* Action Buttons */}
               <div className="flex flex-wrap gap-4 mb-8">
                 <Button
-                  onClick={handlePlay}
+                  onClick={() => handlePlay()}
                   size="lg"
                   className="bg-red-600 hover:bg-red-700 text-white font-bold px-8 py-3 text-lg rounded-md flex items-center gap-3"
                 >
                   <Play className="w-5 h-5 fill-current" />
                   {content.type === 'tv' ? `Play S${selectedSeason}:E${selectedEpisode}` : 'Play Now'}
                 </Button>
-                
+
+                {resumeAvailable && resumeProgress && (
+                  <Button
+                    onClick={handleResume}
+                    variant="outline"
+                    size="lg"
+                    className="border-red-500 text-red-400 hover:bg-red-600/20 font-bold px-8 py-3 text-lg rounded-md flex items-center gap-3"
+                  >
+                    <RotateCcw className="w-5 h-5" />
+                    Resume
+                    {resumeDetails?.episodeLabel ? ` ${resumeDetails.episodeLabel}` : ''}
+                    {resumeDetails?.timeLabel ? ` • ${resumeDetails.timeLabel}` : ''}
+                  </Button>
+                )}
+
                 <Button
                   onClick={handleAddToWatchlist}
                   variant="outline"

--- a/src/components/content-rows.tsx
+++ b/src/components/content-rows.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, TrendingUp, Star, Clock, Zap, ChevronLeft } from 'lucide-
 import NetflixCard from './netflix-card';
 import { NetflixCardSkeleton } from './netflix-loading';
 import { tmdbService } from '../services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 
 // Content section interface
 interface ContentSection {
@@ -130,9 +131,26 @@ export function ContentRows() {
     loadAllContent();
   }, []);
 
-  const handleCardClick = (item: any) => {
-    // Use TMDB ID consistently for routing
+  const handleCardClick = (item: any, options?: PlaybackOptions) => {
     const contentId = item.tmdb_id || item.id;
+    const params = new URLSearchParams();
+
+    if (options?.season) {
+      params.set('s', options.season.toString());
+    }
+    if (options?.episode) {
+      params.set('e', options.episode.toString());
+    }
+    if (options?.resumeAt) {
+      params.set('t', Math.floor(options.resumeAt).toString());
+    }
+
+    if (params.size > 0) {
+      const query = params.toString();
+      navigate(`/watch/${item.type}/${contentId}?${query}`);
+      return;
+    }
+
     navigate(`/details/${item.type}/${contentId}`);
   };
 
@@ -292,7 +310,7 @@ export function ContentRows() {
                     >
                       <NetflixCard
                         content={item}
-                        onPlay={() => handleCardClick(item)}
+                        onPlay={(_contentId, options) => handleCardClick(item, options)}
                         size="medium"
                       />
                     </motion.div>

--- a/src/components/content-search.tsx
+++ b/src/components/content-search.tsx
@@ -4,11 +4,12 @@ import { Search, Hash, Loader2, X } from 'lucide-react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { tmdbService, type ContentItem } from '@/services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 import NetflixCard from '@/components/netflix-card';
 import { useNavigate } from 'react-router-dom';
 
 interface ContentSearchProps {
-  onPlayContent?: (content: ContentItem) => void;
+  onPlayContent?: (content: ContentItem, options?: PlaybackOptions) => void;
 }
 
 export function ContentSearch({ onPlayContent }: ContentSearchProps) {
@@ -190,9 +191,9 @@ export function ContentSearch({ onPlayContent }: ContentSearchProps) {
     }
   };
 
-  const handlePlay = (content: ContentItem) => {
+  const handlePlay = (content: ContentItem, options?: PlaybackOptions) => {
     if (onPlayContent) {
-      onPlayContent(content);
+      onPlayContent(content, options);
     } else {
       navigate(`/details/${content.type}/${content.tmdb_id}`);
     }
@@ -393,7 +394,7 @@ export function ContentSearch({ onPlayContent }: ContentSearchProps) {
                     >
                       <NetflixCard
                         content={convertToCardFormat(item)}
-                        onPlay={() => handlePlay(item)}
+                        onPlay={(_contentId, options) => handlePlay(item, options)}
                         size="medium"
                       />
                     </motion.div>

--- a/src/components/lazy-netflix-card.tsx
+++ b/src/components/lazy-netflix-card.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { performanceOptimizationService } from '@/services/performance-optimization-service';
 import NetflixCard from './netflix-card';
+import type { PlaybackOptions } from '@/types/playback';
 
 interface LazyNetflixCardProps {
   content: {
@@ -20,7 +21,7 @@ interface LazyNetflixCardProps {
     episodes?: number;
     tmdb_id?: number;
   };
-  onPlay: (contentId: string) => void;
+  onPlay: (contentId: string, options?: PlaybackOptions) => void;
   onAddToList?: (contentId: string) => void;
   size?: 'small' | 'medium' | 'large';
   compact?: boolean;

--- a/src/components/movie-suggestions.tsx
+++ b/src/components/movie-suggestions.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Movie } from '@/services/geminiServices';
 import { tmdbService, type ContentItem } from '@/services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 import { aiRecommendationService } from '@/services/ai-recommendation-service';
 import { smartContentMapper } from '@/services/smart-content-mapper';
 import { errorHandlingService } from '@/services/error-handling-service';
@@ -460,14 +461,36 @@ export function MovieSuggestions() {
   };
 
   // Handle play button navigation with enhanced tracking and error handling
-  const handlePlay = (contentId: string) => {
+  const handlePlay = (contentId: string, options?: PlaybackOptions) => {
     const startTime = Date.now();
     console.log('Playing content with ID:', contentId);
     
     const allContent = [...dailyContent, ...messages.flatMap(m => m.suggestions || [])];
-    
+
     // Find content by TMDB ID (contentId should be TMDB ID from NetflixCard)
     const item = allContent.find(item => item.tmdb_id.toString() === contentId);
+
+    const buildQueryString = (playback?: PlaybackOptions) => {
+      if (!playback) {
+        return '';
+      }
+
+      const params = new URLSearchParams();
+      if (playback.season) {
+        params.set('s', playback.season.toString());
+      }
+      if (playback.episode) {
+        params.set('e', playback.episode.toString());
+      }
+      if (playback.resumeAt) {
+        params.set('t', Math.floor(playback.resumeAt).toString());
+      }
+
+      return params.toString();
+    };
+
+    const queryString = buildQueryString(options);
+    const withQuery = (path: string) => (queryString ? `${path}?${queryString}` : path);
     
     // Enhanced tracking with more detailed metadata
     if (item) {
@@ -503,7 +526,7 @@ export function MovieSuggestions() {
         // Navigate to the watch page with the correct content type and ID
         // Use the same routing pattern as other components in the application
         const contentType = item.type;
-        navigate(`/watch/${contentType}/${item.tmdb_id}`);
+        navigate(withQuery(`/watch/${contentType}/${item.tmdb_id}`));
         
       } catch (error) {
         console.error('Error generating streaming URL:', error);
@@ -517,7 +540,7 @@ export function MovieSuggestions() {
         
         // Fallback to direct navigation
         const contentType = item.type;
-        navigate(`/watch/${contentType}/${item.tmdb_id}`);
+        navigate(withQuery(`/watch/${contentType}/${item.tmdb_id}`));
       }
     } else {
       console.error('Content not found for TMDB ID:', contentId);
@@ -557,7 +580,7 @@ export function MovieSuggestions() {
         }
         
         console.log(`Fallback navigation: ${contentType}/${numericId}`);
-        navigate(`/watch/${contentType}/${numericId}`);
+        navigate(withQuery(`/watch/${contentType}/${numericId}`));
         
         // Track successful fallback navigation
         trackUserInteraction('play_button', isFromDaily ? 'daily' : 'chat', contentId, contentType as 'movie' | 'tv', {
@@ -863,7 +886,7 @@ export function MovieSuggestions() {
                 >
                   <BatchContentLoader
                     content={dailyContent.map(content => convertToCardFormat(content))}
-                    onPlay={(contentId) => handlePlay(contentId)}
+                    onPlay={(contentId, options) => handlePlay(contentId, options)}
                     size="small"
                     gridCols={3}
                     batchSize={6}
@@ -1000,7 +1023,7 @@ export function MovieSuggestions() {
                               </div>
                               <BatchContentLoader
                                 content={message.suggestions.map(content => convertToCardFormat(content))}
-                                onPlay={(contentId) => handlePlay(contentId)}
+                                onPlay={(contentId, options) => handlePlay(contentId, options)}
                                 size="small"
                                 gridCols={2}
                                 batchSize={4}

--- a/src/components/netflix-card.tsx
+++ b/src/components/netflix-card.tsx
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import { Play, Plus, ThumbsUp, Star, Heart, Info } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Play, Plus, ThumbsUp, Star, Heart, Info, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { watchlistService } from '@/services/watchlist-service';
 import { useNavigate } from 'react-router-dom';
+import { useWatchProgress } from '@/hooks/use-watch-progress';
+import type { PlaybackOptions } from '@/types/playback';
 
 interface NetflixCardProps {
   content: {
@@ -22,7 +24,7 @@ interface NetflixCardProps {
     episodes?: number;
     tmdb_id?: number; // Add TMDB ID for proper routing
   };
-  onPlay: (contentId: string) => void;
+  onPlay: (contentId: string, options?: PlaybackOptions) => void;
   onAddToList?: (contentId: string) => void;
   size?: 'small' | 'medium' | 'large';
   compact?: boolean;
@@ -40,6 +42,52 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
   const [imageLoaded, setImageLoaded] = useState(false);
   const [imageError, setImageError] = useState(false);
   const [isInWatchlist, setIsInWatchlist] = useState(false);
+  const progressMediaType: 'movie' | 'tv' = content.type === 'movie' ? 'movie' : 'tv';
+  const resumeProgress = useWatchProgress(content.tmdb_id, progressMediaType);
+
+  const progressPercent = useMemo(() => {
+    if (!resumeProgress?.durationSeconds || resumeProgress.durationSeconds <= 0) {
+      return null;
+    }
+    return Math.min(100, Math.round((resumeProgress.positionSeconds / resumeProgress.durationSeconds) * 100));
+  }, [resumeProgress]);
+
+  const resumeDetails = useMemo(() => {
+    if (!resumeProgress || resumeProgress.positionSeconds < 5) {
+      return null;
+    }
+
+    const totalSeconds = Math.floor(resumeProgress.positionSeconds);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const timeParts: string[] = [];
+    if (hours > 0) {
+      timeParts.push(`${hours}h`);
+    }
+    if (minutes > 0 || hours === 0) {
+      timeParts.push(`${minutes}m`);
+    }
+    if (hours === 0 && minutes === 0) {
+      timeParts.push(`${seconds}s`);
+    }
+
+    const episodeLabel = resumeProgress.mediaType === 'tv'
+      ? [
+          resumeProgress.season ? `S${resumeProgress.season}` : null,
+          resumeProgress.episode ? `E${resumeProgress.episode}` : null,
+        ]
+          .filter(Boolean)
+          .join('') || 'Episode'
+      : null;
+
+    return {
+      timeLabel: timeParts.join(' '),
+      episodeLabel,
+    };
+  }, [resumeProgress]);
+  const hasResume = !!resumeDetails;
 
   useEffect(() => {
     setIsInWatchlist(watchlistService.isInWatchlist(content.imdb_id));
@@ -51,11 +99,34 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
     large: compact ? 'w-full h-40' : 'w-56 h-80 max-h-80'
   };
 
-  const handlePlay = () => {
-    // Always use TMDB ID for consistent streaming navigation
-    // This ensures compatibility with the parent component's lookup logic
+  const triggerPlay = (options?: PlaybackOptions, event?: React.MouseEvent) => {
+    if (event) {
+      event.stopPropagation();
+    }
+
     const playId = content.tmdb_id?.toString() || content.id;
-    onPlay(playId);
+    onPlay(playId, options);
+  };
+
+  const handlePlay = (event?: React.MouseEvent) => {
+    triggerPlay(undefined, event);
+  };
+
+  const handleResumeClick = (event: React.MouseEvent) => {
+    if (!resumeProgress) {
+      triggerPlay(undefined, event);
+      return;
+    }
+
+    triggerPlay(
+      {
+        resumeAt: resumeProgress.positionSeconds,
+        season: resumeProgress.season,
+        episode: resumeProgress.episode,
+        mediaType: resumeProgress.mediaType,
+      },
+      event,
+    );
   };
 
   const handleCardClick = () => {
@@ -180,11 +251,22 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
 
         {/* Compact Actions */}
         <div className="flex items-center gap-2">
+          {hasResume && (
+            <Button
+              variant="secondary"
+              size="sm"
+              className="bg-red-600 text-white hover:bg-red-500"
+              onClick={(event) => handleResumeClick(event)}
+            >
+              <RotateCcw className="w-4 h-4 mr-1" />
+              Resume
+            </Button>
+          )}
           <Button
             variant="secondary"
             size="sm"
             className="bg-white text-black hover:bg-gray-200"
-            onClick={handlePlay}
+            onClick={(event) => handlePlay(event)}
           >
             <Play className="w-4 h-4 mr-1 fill-black" />
             Play
@@ -265,16 +347,32 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
         >
           {/* Action Buttons Row */}
           <div className="flex items-center justify-between mb-2">
-            <Button
-              variant="secondary" 
-              size="sm"
-              className="bg-white text-black hover:bg-gray-200 font-medium px-3 py-1 text-xs"
-              onClick={handlePlay}
-            >
-              <Play className="w-3 h-3 mr-1 fill-black" />
-              Play
-            </Button>
-            
+            <div className="flex items-center gap-2">
+              {hasResume && (
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="bg-red-600 text-white hover:bg-red-500 font-medium px-3 py-1 text-xs"
+                  onClick={(event) => handleResumeClick(event)}
+                >
+                  <RotateCcw className="w-3 h-3 mr-1" />
+                  Resume
+                  {resumeDetails?.episodeLabel && (
+                    <span className="ml-1 text-[10px] opacity-80">{resumeDetails.episodeLabel}</span>
+                  )}
+                </Button>
+              )}
+              <Button
+                variant="secondary"
+                size="sm"
+                className="bg-white text-black hover:bg-gray-200 font-medium px-3 py-1 text-xs"
+                onClick={(event) => handlePlay(event)}
+              >
+                <Play className="w-3 h-3 mr-1 fill-black" />
+                Play
+              </Button>
+            </div>
+
             <div className="flex items-center gap-1">
               <Button
                 variant="ghost"
@@ -322,6 +420,17 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
             <span>{duration}</span>
           </div>
 
+          {hasResume && resumeDetails && (
+            <div className="flex items-center gap-1 text-[10px] uppercase tracking-wide text-red-300 mb-1">
+              <RotateCcw className="w-3 h-3" />
+              <span>
+                Resume
+                {resumeDetails.episodeLabel ? ` ${resumeDetails.episodeLabel}` : ''}
+                {resumeDetails.timeLabel ? ` • ${resumeDetails.timeLabel}` : ''}
+              </span>
+            </div>
+          )}
+
           {/* Genres */}
           {content.genres && content.genres.length > 0 && (
             <div className="flex flex-wrap gap-1 mb-1">
@@ -343,6 +452,15 @@ const NetflixCard: React.FC<NetflixCardProps> = ({
             </p>
           )}
         </div>
+
+        {progressPercent !== null && (
+          <div className="absolute bottom-0 left-0 right-0 h-1 bg-white/10">
+            <div
+              className="h-full bg-red-600"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        )}
     </div>
   );
 };

--- a/src/components/netflix-enhancement.tsx
+++ b/src/components/netflix-enhancement.tsx
@@ -1,6 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bell, X, CheckCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { useLastWatchedProgress } from '@/hooks/use-watch-progress';
 
 
 // Toast notification system
@@ -14,6 +17,15 @@ interface Toast {
 
 export function NetflixToast() {
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const navigate = useNavigate();
+  const lastWatched = useLastWatchedProgress();
+  const [resumeDismissed, setResumeDismissed] = useState(false);
+
+  useEffect(() => {
+    if (lastWatched) {
+      setResumeDismissed(false);
+    }
+  }, [lastWatched?.tmdbId, lastWatched?.updatedAt]);
 
   const addToast = (toast: Omit<Toast, 'id'>) => {
     const id = Math.random().toString(36).substr(2, 9);
@@ -56,8 +68,132 @@ export function NetflixToast() {
     }
   };
 
+  const resumeDetails = useMemo(() => {
+    if (!lastWatched || lastWatched.positionSeconds < 5) {
+      return null;
+    }
+
+    const totalSeconds = Math.floor(lastWatched.positionSeconds);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const timeParts: string[] = [];
+    if (hours > 0) {
+      timeParts.push(`${hours}h`);
+    }
+    if (minutes > 0 || hours === 0) {
+      timeParts.push(`${minutes}m`);
+    }
+    if (hours === 0 && minutes === 0) {
+      timeParts.push(`${seconds}s`);
+    }
+
+    const episodeLabel = lastWatched.mediaType === 'tv'
+      ? [
+          lastWatched.season ? `S${lastWatched.season}` : null,
+          lastWatched.episode ? `E${lastWatched.episode}` : null,
+        ]
+          .filter(Boolean)
+          .join('') || 'Episode'
+      : null;
+
+    const progressPercent = lastWatched.durationSeconds && lastWatched.durationSeconds > 0
+      ? Math.min(100, Math.round((lastWatched.positionSeconds / lastWatched.durationSeconds) * 100))
+      : null;
+
+    return {
+      timeLabel: timeParts.join(' '),
+      episodeLabel,
+      progressPercent,
+    };
+  }, [lastWatched]);
+
+  const handleResume = () => {
+    if (!lastWatched) {
+      return;
+    }
+
+    const params = new URLSearchParams();
+    if (lastWatched.mediaType === 'tv') {
+      if (lastWatched.season) {
+        params.set('s', lastWatched.season.toString());
+      }
+      if (lastWatched.episode) {
+        params.set('e', lastWatched.episode.toString());
+      }
+    }
+
+    if (lastWatched.positionSeconds) {
+      params.set('t', Math.floor(lastWatched.positionSeconds).toString());
+    }
+
+    const path = `/watch/${lastWatched.mediaType}/${lastWatched.tmdbId}`;
+    const query = params.toString();
+    navigate(query ? `${path}?${query}` : path);
+  };
+
   return (
-    <div className="fixed top-4 right-4 z-50 space-y-2">
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col items-end space-y-3">
+      <AnimatePresence>
+        {resumeDetails && lastWatched && !resumeDismissed && (
+          <motion.div
+            key="resume-toast"
+            initial={{ opacity: 0, x: 80, scale: 0.9 }}
+            animate={{ opacity: 1, x: 0, scale: 1 }}
+            exit={{ opacity: 0, x: 80, scale: 0.9 }}
+            className="w-72 rounded-xl bg-slate-900/95 backdrop-blur-md shadow-2xl border border-red-500/40 overflow-hidden"
+          >
+            <div className="flex">
+              {lastWatched.poster && (
+                <img
+                  src={lastWatched.poster}
+                  alt={lastWatched.title}
+                  className="w-20 h-24 object-cover"
+                />
+              )}
+              <div className="flex-1 p-3">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-xs uppercase text-red-400 tracking-wide">Continue Watching</p>
+                    <h4 className="text-sm font-semibold text-white line-clamp-2">{lastWatched.title}</h4>
+                    {resumeDetails.episodeLabel && (
+                      <p className="text-[10px] text-slate-300 mt-1">{resumeDetails.episodeLabel}</p>
+                    )}
+                    {resumeDetails.timeLabel && (
+                      <p className="text-[10px] text-slate-400 mt-1">Paused at {resumeDetails.timeLabel}</p>
+                    )}
+                  </div>
+                  <button
+                    className="text-slate-400 hover:text-white transition-colors"
+                    onClick={() => setResumeDismissed(true)}
+                    aria-label="Dismiss resume suggestion"
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+
+                <div className="mt-3 flex items-center justify-between gap-2">
+                  <Button size="sm" className="bg-red-600 hover:bg-red-500 text-white px-3" onClick={handleResume}>
+                    Resume
+                  </Button>
+                  {resumeDetails.progressPercent !== null && (
+                    <div className="flex-1 ml-2">
+                      <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-red-500"
+                          style={{ width: `${resumeDetails.progressPercent}%` }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       <AnimatePresence>
         {toasts.map((toast) => (
           <motion.div

--- a/src/components/netflix-hero.tsx
+++ b/src/components/netflix-hero.tsx
@@ -3,11 +3,12 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Play, Info, Star, Volume2, VolumeX, Plus, ThumbsUp, Heart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { tmdbService, type ContentItem } from '@/services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 import { watchlistService } from '@/services/watchlist-service';
 import { useNavigate } from 'react-router-dom';
 
 interface NetflixHeroProps {
-  onPlayContent: (content: ContentItem) => void;
+  onPlayContent: (content: ContentItem, options?: PlaybackOptions) => void;
 }
 
 export function NetflixHero({ onPlayContent }: NetflixHeroProps) {

--- a/src/components/ultra-search.tsx
+++ b/src/components/ultra-search.tsx
@@ -8,6 +8,7 @@ import NetflixCard from './netflix-card';
 import { NetflixLoading } from './netflix-loading';
 import { tmdbService } from '../services/tmdb-service';
 import { ContentItem } from '../services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 import { useNavigate } from 'react-router-dom';
 
 export const UltraSearch: React.FC = () => {
@@ -130,7 +131,24 @@ export const UltraSearch: React.FC = () => {
     }
   };
 
-  const handlePlay = (content: ContentItem) => {
+  const handlePlay = (content: ContentItem, options?: PlaybackOptions) => {
+    const params = new URLSearchParams();
+    if (options?.season) {
+      params.set('s', options.season.toString());
+    }
+    if (options?.episode) {
+      params.set('e', options.episode.toString());
+    }
+    if (options?.resumeAt) {
+      params.set('t', Math.floor(options.resumeAt).toString());
+    }
+
+    const query = params.toString();
+    if (query) {
+      navigate(`/watch/${content.type}/${content.tmdb_id}?${query}`);
+      return;
+    }
+
     navigate(`/watch/${content.type}/${content.tmdb_id}`);
   };
 
@@ -397,7 +415,7 @@ export const UltraSearch: React.FC = () => {
                     >
                       <NetflixCard
                         content={convertToCardFormat(item)}
-                        onPlay={() => handlePlay(item)}
+                        onPlay={(_contentId, options) => handlePlay(item, options)}
                         size="medium"
                       />
                     </motion.div>

--- a/src/components/watchlist-view.tsx
+++ b/src/components/watchlist-view.tsx
@@ -7,9 +7,10 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@
 import NetflixCard from '@/components/netflix-card';
 import { watchlistService, type WatchlistItem } from '@/services/watchlist-service';
 import { type ContentItem } from '@/services/tmdb-service';
+import type { PlaybackOptions } from '@/types/playback';
 
 interface WatchlistViewProps {
-  onPlayContent?: (content: ContentItem) => void;
+  onPlayContent?: (content: ContentItem, options?: PlaybackOptions) => void;
 }
 
 export function WatchlistView({ onPlayContent }: WatchlistViewProps) {
@@ -61,16 +62,17 @@ export function WatchlistView({ onPlayContent }: WatchlistViewProps) {
     setFilteredWatchlist(filtered);
   };
 
-  const handlePlay = (item: WatchlistItem) => {
+  const handlePlay = (item: WatchlistItem, options?: PlaybackOptions) => {
+    const defaultType = item.type === 'anime' ? 'tv' : item.type;
+
     if (onPlayContent) {
-      // Convert WatchlistItem to ContentItem
       const contentItem: ContentItem = {
         id: parseInt(item.id),
         tmdb_id: parseInt(item.id),
         imdb_id: item.imdb_id,
         title: item.title,
         originalTitle: item.title,
-        type: item.type === 'anime' ? 'tv' : item.type as 'movie' | 'tv',
+        type: defaultType as 'movie' | 'tv',
         year: item.year || null,
         releaseDate: item.year ? `${item.year}-01-01` : '',
         overview: '',
@@ -86,12 +88,26 @@ export function WatchlistView({ onPlayContent }: WatchlistViewProps) {
         episodes: null,
         status: null,
         isAdult: false,
-        streamUrl: ''
+        streamUrl: '',
       };
-      onPlayContent(contentItem);
-    } else {
-      navigate(`/watch/${item.type}/${item.imdb_id}`);
+      onPlayContent(contentItem, options);
+      return;
     }
+
+    const params = new URLSearchParams();
+    if (options?.season) {
+      params.set('s', options.season.toString());
+    }
+    if (options?.episode) {
+      params.set('e', options.episode.toString());
+    }
+    if (options?.resumeAt) {
+      params.set('t', Math.floor(options.resumeAt).toString());
+    }
+
+    const query = params.toString();
+    const basePath = `/watch/${defaultType}/${item.imdb_id}`;
+    navigate(query ? `${basePath}?${query}` : basePath);
   };
 
   const handleRemoveFromWatchlist = (tmdbId: string) => {
@@ -249,7 +265,7 @@ export function WatchlistView({ onPlayContent }: WatchlistViewProps) {
                 >
                   <NetflixCard
                     content={convertToNetflixCardFormat(item)}
-                    onPlay={() => handlePlay(item)}
+                    onPlay={(_contentId, options) => handlePlay(item, options)}
                     onAddToList={() => handleRemoveFromWatchlist(item.imdb_id)}
                     size="medium"
                   />
@@ -273,7 +289,7 @@ export function WatchlistView({ onPlayContent }: WatchlistViewProps) {
                 >
                   <NetflixCard
                     content={convertToNetflixCardFormat(item)}
-                    onPlay={() => handlePlay(item)}
+                    onPlay={(_contentId, options) => handlePlay(item, options)}
                     onAddToList={() => handleRemoveFromWatchlist(item.imdb_id)}
                     compact={true}
                   />

--- a/src/hooks/use-watch-progress.ts
+++ b/src/hooks/use-watch-progress.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import { watchProgressService, type WatchProgressEntry, type WatchProgressMediaType } from '@/services/watch-progress-service';
+
+export function useWatchProgress(
+  tmdbId?: number,
+  mediaType?: WatchProgressMediaType,
+  season?: number,
+  episode?: number,
+) {
+  const [progress, setProgress] = useState<WatchProgressEntry | null>(() => {
+    if (tmdbId === undefined || !mediaType) {
+      return null;
+    }
+
+    if (mediaType === 'tv' && season && episode) {
+      return watchProgressService.getProgress({ tmdbId, mediaType, season, episode });
+    }
+
+    return watchProgressService.getLatestProgress(tmdbId, mediaType);
+  });
+
+  useEffect(() => {
+    if (tmdbId === undefined || !mediaType) {
+      setProgress(null);
+      return;
+    }
+
+    const update = () => {
+      if (mediaType === 'tv' && season && episode) {
+        setProgress(watchProgressService.getProgress({ tmdbId, mediaType, season, episode }));
+      } else {
+        setProgress(watchProgressService.getLatestProgress(tmdbId, mediaType));
+      }
+    };
+
+    update();
+    return watchProgressService.subscribe(update);
+  }, [tmdbId, mediaType, season, episode]);
+
+  return progress;
+}
+
+export function useLastWatchedProgress() {
+  const [progress, setProgress] = useState<WatchProgressEntry | null>(() => watchProgressService.getLastWatched());
+
+  useEffect(() => {
+    const update = () => {
+      setProgress(watchProgressService.getLastWatched());
+    };
+
+    update();
+    return watchProgressService.subscribe(update);
+  }, []);
+
+  return progress;
+}

--- a/src/services/auth-service.ts
+++ b/src/services/auth-service.ts
@@ -1,6 +1,7 @@
 import { supabaseClient } from '@/lib/supabase-client';
 import type { Session, User } from '@supabase/supabase-js';
 import { WATCHLIST_STORAGE_KEY_PREFIX, watchlistService } from './watchlist-service';
+import { watchProgressService } from './watch-progress-service';
 
 export interface UserProfile {
   id: string;
@@ -76,12 +77,14 @@ class AuthService {
         user: userProfile,
       };
       watchlistService.setUserContext(userProfile.id);
+      watchProgressService.setUserContext(userProfile.id);
     } else {
       this.authState = {
         isAuthenticated: false,
         user: null,
       };
       watchlistService.setUserContext(null);
+      watchProgressService.setUserContext(null);
     }
 
     this.notifyListeners();

--- a/src/services/superembed-service.ts
+++ b/src/services/superembed-service.ts
@@ -15,6 +15,8 @@ export interface SuperEmbedOptions {
   useVip?: boolean;
   checkAvailability?: boolean;
   subtitle?: SuperEmbedSubtitleOptions;
+  startTimeSeconds?: number;
+  autoplay?: boolean;
 }
 
 export function normalizeImdbId(imdbId: string): string {
@@ -62,6 +64,18 @@ export function buildSuperEmbedUrl(type: SuperEmbedMediaType, options: SuperEmbe
   if (options.subtitle) {
     params.set('sub_url', options.subtitle.url);
     params.set('sub_label', options.subtitle.label);
+  }
+
+  if (options.autoplay) {
+    params.set('autoplay', '1');
+  }
+
+  if (options.startTimeSeconds && options.startTimeSeconds > 0) {
+    const resumeAt = Math.max(0, Math.floor(options.startTimeSeconds));
+    const resumeValue = resumeAt.toString();
+    params.set('start', resumeValue);
+    params.set('t', resumeValue);
+    params.set('time', resumeValue);
   }
 
   const basePath = options.useVip ? `${SUPEREMBED_BASE}directstream.php` : `${SUPEREMBED_BASE}`;

--- a/src/services/tmdb-service.ts
+++ b/src/services/tmdb-service.ts
@@ -340,7 +340,7 @@ class TMDBService {
     type: 'movie' | 'tv',
     season?: number,
     episode?: number,
-    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle'>
+    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle' | 'startTimeSeconds' | 'autoplay'>
   ): string {
     const trimmedId = typeof id === 'string' ? id.trim() : id;
     const isImdbId = typeof trimmedId === 'string' && trimmedId.startsWith('tt');
@@ -366,7 +366,7 @@ class TMDBService {
     type: 'movie' | 'tv',
     season?: number,
     episode?: number,
-    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle'>
+    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle' | 'startTimeSeconds' | 'autoplay'>
   ): string {
     return this.generateSuperEmbedUrl(id, type, season, episode, extras);
   }
@@ -377,7 +377,7 @@ class TMDBService {
     type: 'movie' | 'tv',
     season?: number,
     episode?: number,
-    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle'>
+    extras?: Pick<SuperEmbedOptions, 'useVip' | 'checkAvailability' | 'subtitle' | 'startTimeSeconds' | 'autoplay'>
   ): string {
     return this.generateSuperEmbedUrl(imdbId, type, season, episode, extras);
   }

--- a/src/services/watch-progress-service.ts
+++ b/src/services/watch-progress-service.ts
@@ -1,0 +1,221 @@
+const WATCH_PROGRESS_STORAGE_PREFIX = 'streall_watch_progress';
+
+export type WatchProgressMediaType = 'movie' | 'tv';
+
+export interface WatchProgressMetadata {
+  tmdbId: number;
+  imdbId?: string;
+  mediaType: WatchProgressMediaType;
+  season?: number;
+  episode?: number;
+  title: string;
+  poster?: string | null;
+  backdropPath?: string | null;
+  episodeTitle?: string | null;
+}
+
+export interface WatchProgressEntry extends WatchProgressMetadata {
+  positionSeconds: number;
+  durationSeconds?: number;
+  updatedAt: string;
+}
+
+interface UpdateProgressOptions {
+  positionSeconds: number;
+  durationSeconds?: number;
+  force?: boolean;
+}
+
+export class WatchProgressService {
+  private storageKey = WATCH_PROGRESS_STORAGE_PREFIX;
+  private progressMap = new Map<string, WatchProgressEntry>();
+  private listeners = new Set<() => void>();
+
+  constructor() {
+    this.loadFromStorage();
+  }
+
+  setUserContext(userId: string | null) {
+    const nextKey = userId ? `${WATCH_PROGRESS_STORAGE_PREFIX}_${userId}` : WATCH_PROGRESS_STORAGE_PREFIX;
+    if (nextKey === this.storageKey) {
+      return;
+    }
+
+    this.storageKey = nextKey;
+    this.progressMap.clear();
+    this.loadFromStorage();
+    this.notify();
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getProgress(metadata: Pick<WatchProgressMetadata, 'tmdbId' | 'mediaType'> & { season?: number; episode?: number }): WatchProgressEntry | null {
+    const key = this.buildKey(metadata.tmdbId, metadata.mediaType, metadata.season, metadata.episode);
+    return this.progressMap.get(key) ?? null;
+  }
+
+  getLatestProgress(tmdbId: number, mediaType: WatchProgressMediaType): WatchProgressEntry | null {
+    const prefix = this.buildKeyPrefix(tmdbId, mediaType);
+    const entries: WatchProgressEntry[] = [];
+
+    for (const [key, value] of this.progressMap.entries()) {
+      if (key.startsWith(prefix)) {
+        entries.push(value);
+      }
+    }
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    const sorted = entries.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return sorted.length > 0 ? sorted[0]! : null;
+  }
+
+  getLastWatched(): WatchProgressEntry | null {
+    if (this.progressMap.size === 0) {
+      return null;
+    }
+
+    const entries = Array.from(this.progressMap.values());
+    const sorted = entries.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+    return sorted.length > 0 ? sorted[0]! : null;
+  }
+
+  updateProgress(metadata: WatchProgressMetadata, options: UpdateProgressOptions) {
+    if (!metadata.tmdbId || !metadata.mediaType) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const safePosition = Number.isFinite(options.positionSeconds) ? Math.max(0, options.positionSeconds) : 0;
+    const safeDuration = options.durationSeconds && Number.isFinite(options.durationSeconds)
+      ? Math.max(0, options.durationSeconds)
+      : undefined;
+
+    if (!options.force) {
+      if (safeDuration && safeDuration > 0 && safePosition / safeDuration >= 0.95) {
+        this.clearProgress(metadata);
+        return;
+      }
+
+      if (safePosition < 5) {
+        // Ignore near-zero progress updates unless forced so we don't create noisy records
+        return;
+      }
+    }
+
+    const key = this.buildKey(metadata.tmdbId, metadata.mediaType, metadata.season, metadata.episode);
+    const existing = this.progressMap.get(key);
+
+    if (!options.force && existing) {
+      const diff = Math.abs(existing.positionSeconds - safePosition);
+      if (diff < 5 && (!safeDuration || existing.durationSeconds === safeDuration)) {
+        return;
+      }
+    }
+
+    const entry: WatchProgressEntry = {
+      ...metadata,
+      positionSeconds: safePosition,
+      durationSeconds: safeDuration,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.progressMap.set(key, entry);
+    this.persist();
+    this.notify();
+  }
+
+  clearProgress(metadata: Pick<WatchProgressMetadata, 'tmdbId' | 'mediaType'> & { season?: number; episode?: number }) {
+    const key = this.buildKey(metadata.tmdbId, metadata.mediaType, metadata.season, metadata.episode);
+    if (this.progressMap.delete(key)) {
+      this.persist();
+      this.notify();
+    }
+  }
+
+  clearAll() {
+    if (this.progressMap.size === 0) {
+      return;
+    }
+
+    this.progressMap.clear();
+    this.persist();
+    this.notify();
+  }
+
+  private notify() {
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (error) {
+        console.error('[watch-progress] listener error', error);
+      }
+    }
+  }
+
+  private loadFromStorage() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const stored = window.localStorage.getItem(this.storageKey);
+      if (!stored) {
+        return;
+      }
+
+      const parsed: WatchProgressEntry[] = JSON.parse(stored);
+      this.progressMap.clear();
+
+      for (const entry of parsed) {
+        if (entry && typeof entry.tmdbId === 'number' && entry.mediaType) {
+          const key = this.buildKey(entry.tmdbId, entry.mediaType, entry.season, entry.episode);
+          this.progressMap.set(key, entry);
+        }
+      }
+    } catch (error) {
+      console.error('[watch-progress] Failed to load from storage', error);
+      this.progressMap.clear();
+    }
+  }
+
+  private persist() {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const entries = Array.from(this.progressMap.values());
+      window.localStorage.setItem(this.storageKey, JSON.stringify(entries));
+    } catch (error) {
+      console.error('[watch-progress] Failed to persist progress', error);
+    }
+  }
+
+  private buildKeyPrefix(tmdbId: number, mediaType: WatchProgressMediaType) {
+    return `${mediaType}:${tmdbId}`;
+  }
+
+  private buildKey(tmdbId: number, mediaType: WatchProgressMediaType, season?: number, episode?: number) {
+    const prefix = this.buildKeyPrefix(tmdbId, mediaType);
+    if (mediaType === 'tv') {
+      const seasonPart = season ? `:s${season}` : ':s1';
+      const episodePart = episode ? `:e${episode}` : ':e1';
+      return `${prefix}${seasonPart}${episodePart}`;
+    }
+
+    return `${prefix}:movie`;
+  }
+}
+
+export const watchProgressService = new WatchProgressService();

--- a/src/types/playback.ts
+++ b/src/types/playback.ts
@@ -1,0 +1,6 @@
+export interface PlaybackOptions {
+  resumeAt?: number;
+  season?: number;
+  episode?: number;
+  mediaType?: 'movie' | 'tv';
+}


### PR DESCRIPTION
## Summary
- add a watch progress service and hook to persist per-user playback checkpoints
- surface resume actions on netflix cards, the detail page, and a bottom-right toast while keeping navigation aware of saved offsets
- update player loading to honor resume positions, send progress updates, and extend SuperEmbed URLs with resume parameters

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde9652e908333ab823b2ea733a2c6